### PR TITLE
ephem 4.1.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,8 +11,6 @@ source:
 build:
   number: 0
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
-  ignore_run_exports:
-    - python
 
 requirements:
   build:
@@ -36,8 +34,8 @@ test:
 
 about:
   home: http://rhodesmill.org/pyephem/
-  license: LGPL
-  license_family: LGPL
+  license: MIT
+  license_family: MIT
   license_file: LICENSE
   summary: Basic astronomical computations for Python
   description: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.0.0.2" %}
+{% set version = "4.1.2" %}
 
 package:
   name: ephem
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/e/ephem/ephem-{{ version }}.tar.gz
-  sha256: d03de73ebf6a91681d597eb5b5d43bcf6f0c67e292bba2f9a974734b4f15757e
+  sha256: d65bf7c85d96ca830de82729d9ce54ba854a9625916d8765c1954c1f29680b76
 
 build:
   number: 0


### PR DESCRIPTION
Update ephem to 4.1.2

Version change: bump version number from 4.0.0.2 to 4.1.2
Upstream license: https://github.com/brandon-rhodes/pyephem/blob/master/LICENSE
Upstream setup file: https://github.com/brandon-rhodes/pyephem/blob/master/setup.py

Actions:
1. Fix license name
2. Remove ignore_run_exports

Result:
- all-succeeded
