### PR TITLE
ephem 4.1.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.1.2" %}
+{% set version = "4.1.5" %}
 
 package:
   name: ephem
@@ -6,11 +6,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/e/ephem/ephem-{{ version }}.tar.gz
-  sha256: d65bf7c85d96ca830de82729d9ce54ba854a9625916d8765c1954c1f29680b76
+  sha256: 0c64a8aa401574c75942045b9af70d1656e14c5366151c0cbb400cbeedc2362a
 
 build:
   number: 0
-  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ test:
     - ephem._libastro
 
 about:
-  home: http://rhodesmill.org/pyephem/
+  home: https://rhodesmill.org/pyephem/
   license: MIT
   license_family: MIT
   license_file: LICENSE
@@ -49,8 +49,7 @@ about:
     convenience and ease of use. Both celestial bodies and the observer's
     location on Earth are represented by Python objects, while dates and
     angles automatically print themselves in standard astronomical formats.
-  doc_url: http://rhodesmill.org/pyephem/
-  doc_source_url: https://github.com/brandon-rhodes/pyephem/blob/master/ephem/doc/index.rst
+  doc_url: https://rhodesmill.org/pyephem/
   dev_url: https://github.com/brandon-rhodes/pyephem
 
 extra:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-5802](https://anaconda.atlassian.net/browse/PKG-5802) 
- [Upstream repository](https://github.com/brandon-rhodes/pyephem/tree/4.1.5)
- Requirements: https://github.com/brandon-rhodes/pyephem/blob/4.1.5/setup.py

### Explanation of changes:

- Clean up the recipe by conda-lint

### Notes:

- Updating for https://github.com/AnacondaRecipes/lunarcalendar-ext-feedstock/pull/1 because v4.1.2 seems broken on osx-arm64 for py>=310. And we enable py312 support as well

[PKG-5802]: https://anaconda.atlassian.net/browse/PKG-5802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ